### PR TITLE
Added 'messagetype'-option

### DIFF
--- a/lib/pling/mobilant/gateway.rb
+++ b/lib/pling/mobilant/gateway.rb
@@ -15,11 +15,12 @@ module Pling
         params = {}
 
         # require url parameter
-        params[:message] = message.body
-        params[:to]      = sanitize_identifier(device.identifier)
-        params[:route]   = route
-        params[:key]     = configuration[:key]
-        params[:charset] = configuration[:charset] if configuration[:charset]
+        params[:message]     = message.body
+        params[:to]          = sanitize_identifier(device.identifier)
+        params[:route]       = route
+        params[:key]         = configuration[:key]
+        params[:charset]     = configuration[:charset] if configuration[:charset]
+        params[:messagetype] = configuration[:messagetype] if configuration[:messagetype]
 
         # optional url parameter
         params[:from]    = source if source


### PR DESCRIPTION
I've added 'messagetype' as a configurable value. It is required to be set to 'unicode' for UTF-8 messages.

http://www.mobilant.de/files/Mobilant_Gateway_HTTP_API_Specifications_DE.pdf
